### PR TITLE
use main branch instead of master branch

### DIFF
--- a/pipeline-example.yaml
+++ b/pipeline-example.yaml
@@ -196,7 +196,7 @@ Resources:
       - Name: Email
         DestinationArn: !Ref PipelineSNSTopic
         Branches:
-        - master
+        - main
         Events:
         - all
   CodeBuildProject:
@@ -246,7 +246,7 @@ Resources:
               OutputArtifacts:
                 - Name: "TemplateSource"
               Configuration:
-                BranchName: "master"
+                BranchName: "main"
                 RepositoryName: !Ref ProjectName
               RunOrder: 1
         - Name: Build


### PR DESCRIPTION
Starting on March 4, 2021 at 17:00 UTC, repositories created with an initial commit of code using AWS CloudFormation stacks will use 'main' instead of 'master' as the name of the default branch. 
![image](https://user-images.githubusercontent.com/4614294/110199746-bec2a000-7e0e-11eb-9420-006018655289.png)


This pull request changes the default branch name to `main` instead of `master` as per the new changes. Users can also update their existing repositories by following [this](https://aws.amazon.com/premiumsupport/knowledge-center/codecommit-branch-name-cloudformation/). 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
