### PR TITLE
Python 3.6 is not supported anymore

### DIFF
--- a/base-layer.yaml
+++ b/base-layer.yaml
@@ -141,7 +141,7 @@ Resources:
       Handler: "index.lambda_handler"
       MemorySize: 128
       Role: !GetAtt LambdaRole.Arn
-      Runtime: "python3.6"
+      Runtime: "python3.9"
       Timeout: 10
       Code:
         ZipFile: |
@@ -172,7 +172,7 @@ Resources:
       Handler: "index.lambda_handler"
       MemorySize: 128
       Role: !GetAtt LambdaRole.Arn
-      Runtime: "python3.6"
+      Runtime: "python3.9"
       Timeout: 10
       Code:
         ZipFile: |


### PR DESCRIPTION
This code is not working due to support for Python 3.6.

*Issue #, if available:*
Stack creation failed due to python3.6

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
